### PR TITLE
CSV separator configurable.

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -11,6 +11,10 @@ ksm {
 
   readonly = true
   readonly = ${?KSM_READONLY}
+
+  csv {
+    delimiter = ","
+  }
 }
 
 authorizer {

--- a/src/main/scala/com/github/simplesteph/ksm/AppConfig.scala
+++ b/src/main/scala/com/github/simplesteph/ksm/AppConfig.scala
@@ -50,6 +50,7 @@ class AppConfig(config: Config) {
     val refreshFrequencyMs: Int = ksmConfig.getInt("refresh.frequency.ms")
     val extract: Boolean = ksmConfig.getBoolean("extract")
     val readOnly: Boolean = ksmConfig.getBoolean("readonly")
+    val csvDelimiter: String = ksmConfig.getString("csv.delimiter")
   }
 
   object GRPC {

--- a/src/main/scala/com/github/simplesteph/ksm/parser/CsvAclParser.scala
+++ b/src/main/scala/com/github/simplesteph/ksm/parser/CsvAclParser.scala
@@ -2,6 +2,8 @@ package com.github.simplesteph.ksm.parser
 
 import java.io.Reader
 
+import com.github.simplesteph.ksm.AppConfig
+import com.github.simplesteph.ksm.KafkaSecurityManager.config
 import com.github.simplesteph.ksm.source.SourceAclResult
 import com.github.tototoshi.csv.{CSVFormat, CSVReader, QUOTE_MINIMAL, Quoting}
 import kafka.security.auth._
@@ -41,9 +43,11 @@ object CsvAclParser extends AclParser {
                                  HOST_COL,
   )
 
+  val appConfig: AppConfig = new AppConfig(config)
+
   // we treat empty lines as Nil hence the format override
   implicit val csvFormat: CSVFormat = new CSVFormat {
-    val delimiter: Char = ','
+    val delimiter: Char = appConfig.KSM.csvDelimiter.charAt(0)
     val quoteChar: Char = '"'
     val escapeChar: Char = '"'
     val lineTerminator: String = "\r\n"
@@ -115,13 +119,13 @@ object CsvAclParser extends AclParser {
          r.name,
          a.operation.toString,
          a.permissionType.toString,
-         a.host).mkString(",")
+         a.host).mkString(appConfig.KSM.csvDelimiter)
   }
 
   override def formatAcls(acls: List[(Resource, Acl)]): String = {
     val sb = new StringBuilder
     // header
-    sb.append(EXPECTED_COLS.mkString(","))
+    sb.append(EXPECTED_COLS.mkString(appConfig.KSM.csvDelimiter))
     sb.append(System.getProperty("line.separator"))
     // rows
     acls.foreach {

--- a/src/main/scala/com/github/simplesteph/ksm/parser/CsvAclParser.scala
+++ b/src/main/scala/com/github/simplesteph/ksm/parser/CsvAclParser.scala
@@ -3,9 +3,9 @@ package com.github.simplesteph.ksm.parser
 import java.io.Reader
 
 import com.github.simplesteph.ksm.AppConfig
-import com.github.simplesteph.ksm.KafkaSecurityManager.config
 import com.github.simplesteph.ksm.source.SourceAclResult
 import com.github.tototoshi.csv.{CSVFormat, CSVReader, QUOTE_MINIMAL, Quoting}
+import com.typesafe.config.ConfigFactory
 import kafka.security.auth._
 import org.apache.kafka.common.resource.PatternType
 import org.apache.kafka.common.utils.SecurityUtils
@@ -43,6 +43,7 @@ object CsvAclParser extends AclParser {
                                  HOST_COL,
   )
 
+  val config = ConfigFactory.load()
   val appConfig: AppConfig = new AppConfig(config)
 
   // we treat empty lines as Nil hence the format override


### PR DESCRIPTION
Useful when you use certificates to authenticate users.

In our setup, we use just SSL to authenticate our users. After executing the tool in extraction mode, we found that the output looks like this.

`User:CN=pcsrc-datastream,OU=none,O=none,L=none,ST=none,C=ES,Topic,LITERAL,pc-src-pr-es,Describe,Allow,*`

As you can see, the full Subject Name of the cert is used in the PRINCIPAL, separating its values with commas.

This PR offers the possibility of making the separation character configurable, being `,` the default, to enable using `;` to separate the values in the CSV and make the solution compatible with this approach.

Please, feel free to reject or suggest any improvements, changes,....