### PR TITLE
Authorizer implementation on top of AdminClient, update scala and sbt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.7-SNAPSHOT]
 - Kafka 2.1.1
+- No-zookeeper ACL managing via admin client
+- Scala 2.12.8, sbt 1.2.8
 
 ## [0.6] - 28/01/2019
 - Added Bitbucket Server as an ACL source

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ libraryDependencies += "com.github.simplesteph" %% "kafka-security-manager" % "v
 
 # Configuration 
 
-## Security configuration
+## Security configuration - Zookeeper client
 
 Make sure the app is using a property file and launch options similar to your broker so that it can 
 1. Authenticate to Zookeeper using secure credentials (usually done with JAAS)
@@ -79,6 +79,18 @@ Client {
 };
 ```
 
+## Security configuration - Admin client
+When configured authorizer class is `com.github.simplesteph.ksm.compat.AdminClientAuthorizer`,
+`kafka-security-manager` will use kafka admin client instead of direct zookeeper connection.
+Configuration example would be
+```
+KafkaClient {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  username="admin"
+  password="admin-secret";
+};
+```
+
 ## Configuration file
 
 For a list of configuration see [application.conf](src/main/resources/application.conf). You can customise them using environment variables or create your own `application.conf` file and pass it at runtime doing:
@@ -94,9 +106,17 @@ The [default configurations](src/main/resources/application.conf) can be overwri
 - `KSM_READONLY=false`: enables KSM to synchronize from an External ACL source. The default value is `true`, which prevents KSM from altering ACLs in Zookeeper
 - `KSM_EXTRACT=true`: enable extract mode (get all the ACLs from Kafka formatted as a CSV)
 - `KSM_REFRESH_FREQUENCY_MS=10000`: how often to check for changes in ACLs in Kafka and in the Source. 10000 ms by default
-- `AUTHORIZER_CLASS`: override the authorizer class if you're not using the `SimpleAclAuthorizer`
-- `AUTHORIZER_ZOOKEEPER_CONNECT`: zookeeper connection string
-- `AUTHORIZER_ZOOKEEPER_SET_ACL=true` (default `false`): set to true if you want your ACLs in Zookeeper to be secure (you probably do want them to be secure) - when in doubt set as the same as your Kafka brokers.  
+- `AUTHORIZER_CLASS`: authorizer class for ACL operations. Default is `SimpleAclAuthorizer`, configured with
+  - `AUTHORIZER_ZOOKEEPER_CONNECT`: zookeeper connection string
+  - `AUTHORIZER_ZOOKEEPER_SET_ACL=true` (default `false`): set to true if you want your ACLs in Zookeeper to be secure (you probably do want them to be secure) - when in doubt set as the same as your Kafka brokers.
+  
+  No-zookeeper authorizer class on top of Kafka Admin Client is bundled with KSM as `com.github.simplesteph.ksm.compat.AdminClientAuthorizer`, configured with
+  - `ADMIN_CLIENT_ID` - An id string to pass to the server when making requests, for tracing/audit purposes
+  - `KAFKA_BOOTSTRAP_SERVERS` - a comma-separated list of Kafka brokers in a "bootstrap" Kafka cluster
+  
+     SASL in Admin Client maybe enabled with following options (don't forget `java.security.auth.login.config` system property):
+  - `ADMIN_CLIENT_SECURITY_PROTOCOL` - admin client `security.protocol` (default `PLAINTEXT`)
+  - `ADMIN_CLIENT_SASL_MECHANISM` - admin client `sasl.mechanism` (applies when using SASL protocol, default `PLAIN`)
 - `SOURCE_CLASS`: Source class. Valid values include
     - `com.github.simplesteph.ksm.source.NoSourceAcl` (default): No source for the ACLs. Only use with `KSM_READONLY=true`
     - `com.github.simplesteph.ksm.source.FileSourceAcl`: get the ACL source from a file on disk. Good for POC

--- a/README.md
+++ b/README.md
@@ -110,13 +110,20 @@ The [default configurations](src/main/resources/application.conf) can be overwri
   - `AUTHORIZER_ZOOKEEPER_CONNECT`: zookeeper connection string
   - `AUTHORIZER_ZOOKEEPER_SET_ACL=true` (default `false`): set to true if you want your ACLs in Zookeeper to be secure (you probably do want them to be secure) - when in doubt set as the same as your Kafka brokers.
   
-  No-zookeeper authorizer class on top of Kafka Admin Client is bundled with KSM as `com.github.simplesteph.ksm.compat.AdminClientAuthorizer`, configured with
-  - `ADMIN_CLIENT_ID` - An id string to pass to the server when making requests, for tracing/audit purposes
-  - `KAFKA_BOOTSTRAP_SERVERS` - a comma-separated list of Kafka brokers in a "bootstrap" Kafka cluster
-  
-     SASL in Admin Client maybe enabled with following options (don't forget `java.security.auth.login.config` system property):
-  - `ADMIN_CLIENT_SECURITY_PROTOCOL` - admin client `security.protocol` (default `PLAINTEXT`)
-  - `ADMIN_CLIENT_SASL_MECHANISM` - admin client `sasl.mechanism` (applies when using SASL protocol, default `PLAIN`)
+  No-zookeeper authorizer class on top of Kafka Admin Client is bundled with KSM as `com.github.simplesteph.ksm.compat.AdminClientAuthorizer`,
+  configured with options for `org.apache.kafka.clients.admin.AdminClientConfig`:
+  - `ADMIN_CLIENT_ID` - `client.id`, an id to pass to the server when making requests, for tracing/audit purposes, default `kafka-security-manager`
+  Properties below are not provided to client unless environment variable is set:
+  - `ADMIN_CLIENT_BOOTSTRAP_SERVERS` - `bootstrap.servers`
+  - `ADMIN_CLIENT_SECURITY_PROTOCOL` - `security.protocol`
+  - `ADMIN_CLIENT_SASL_JAAS_CONFIG` -`sasl.jaas.config` - alternative to system jaas configuration
+  - `ADMIN_CLIENT_SASL_MECHANISM` - `sasl.mechanism`
+  - `ADMIN_CLIENT_SSL_KEY_PASSWORD` - `ssl.key.password`
+  - `ADMIN_CLIENT_SSL_KEYSTORE_LOCATION` - `ssl.keystore.location`
+  - `ADMIN_CLIENT_SSL_KEYSTORE_PASSWORD` - `ssl.keystore.password`
+  - `ADMIN_CLIENT_SSL_TRUSTSTORE_LOCATION` - `ssl.truststore.location`
+  - `ADMIN_CLIENT_SSL_TRUSTSTORE_PASSWORD` - `ssl.truststore.password`
+
 - `SOURCE_CLASS`: Source class. Valid values include
     - `com.github.simplesteph.ksm.source.NoSourceAcl` (default): No source for the ACLs. Only use with `KSM_READONLY=true`
     - `com.github.simplesteph.ksm.source.FileSourceAcl`: get the ACL source from a file on disk. Good for POC

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "com.github.simplesteph.ksm"
 
 version := "0.7-SNAPSHOT"
 
-scalaVersion := "2.12.4"
+scalaVersion := "2.12.8"
 
 lazy val root = (project in file("."))
   .enablePlugins(JavaAppPackaging)
@@ -20,6 +20,9 @@ libraryDependencies ++= Seq(
   // kafka
   "org.apache.kafka" %% "kafka" % "2.1.1",
   "io.github.embeddedkafka" %% "embedded-kafka" % "2.1.1" % "test",
+
+  "org.apache.kafka" % "kafka-clients" % "2.1.1", // needed explicitly for proper classPath
+  "org.apache.kafka" % "kafka-clients" % "2.1.1" % Test classifier "test",
 
   // test
   "org.scalatest" %% "scalatest" % "3.0.5" % Test,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.0.4
+sbt.version = 1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.3")
 
 resolvers += "Artima Maven Repository" at "http://repo.artima.com/releases"
 
-addSbtPlugin("com.artima.supersafe" % "sbtplugin" % "1.1.4")
+addSbtPlugin("com.artima.supersafe" % "sbtplugin" % "1.1.7")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -24,6 +24,21 @@ parser {
 authorizer {
   class = "kafka.security.auth.SimpleAclAuthorizer"
   class = ${?AUTHORIZER_CLASS}
+  admin-client-config {
+    // options below needed when AUTHORIZER_CLASS is "com.github.simplesteph.ksm.compat.AdminClientAuthorizer"
+    // see org.apache.kafka.clients.admin.AdminClientConfig for more options
+    "client.id"               = "kafka-security-manager"
+    "client.id"               = ${?ADMIN_CLIENT_ID}
+    "bootstrap.servers"       = ${?ADMIN_CLIENT_BOOTSTRAP_SERVERS}
+    "security.protocol"       = ${?ADMIN_CLIENT_SECURITY_PROTOCOL}
+    "sasl.jaas.config"        = ${?ADMIN_CLIENT_SASL_JAAS_CONFIG}
+    "sasl.mechanism"          = ${?ADMIN_CLIENT_SASL_MECHANISM}
+    "ssl.key.password"        = ${?ADMIN_CLIENT_SSL_KEY_PASSWORD}
+    "ssl.keystore.location"   = ${?ADMIN_CLIENT_SSL_KEYSTORE_LOCATION}
+    "ssl.keystore.password"   = ${?ADMIN_CLIENT_SSL_KEYSTORE_PASSWORD}
+    "ssl.truststore.location" = ${?ADMIN_CLIENT_SSL_TRUSTSTORE_LOCATION}
+    "ssl.truststore.password" = ${?ADMIN_CLIENT_SSL_TRUSTSTORE_PASSWORD}
+  }
   config {
     "zookeeper.connect" = "localhost:2181"
     "zookeeper.connect" = ${?AUTHORIZER_ZOOKEEPER_CONNECT}
@@ -31,15 +46,6 @@ authorizer {
     "zookeeper.session.timeout.ms" = ${?AUTHORIZER_SESSION_TIMEOUT_MS}
     "zookeeper.set.acl" = "false"
     "zookeeper.set.acl" = ${?AUTHORIZER_ZOOKEEPER_SET_ACL}
-    // options below needed when AUTHORIZER_CLASS is "com.github.simplesteph.ksm.compat.AdminClientAuthorizer"
-    // see org.apache.kafka.clients.admin.AdminClientConfig for more options
-    "client.id"         = "kafka-security-manager"
-    "client.id"         = ${?ADMIN_CLIENT_ID}
-    "bootstrap.servers" = ${?KAFKA_BOOTSTRAP_SERVERS}
-    "security.protocol" = "PLAINTEXT"
-    "security.protocol" = ${?ADMIN_CLIENT_SECURITY_PROTOCOL}
-    "sasl.mechanism" = "PLAIN"
-    "sasl.mechanism" = ${?ADMIN_CLIENT_SASL_MECHANISM}
   }
 }
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -31,6 +31,15 @@ authorizer {
     "zookeeper.session.timeout.ms" = ${?AUTHORIZER_SESSION_TIMEOUT_MS}
     "zookeeper.set.acl" = "false"
     "zookeeper.set.acl" = ${?AUTHORIZER_ZOOKEEPER_SET_ACL}
+    // options below needed when AUTHORIZER_CLASS is "com.github.simplesteph.ksm.compat.AdminClientAuthorizer"
+    // see org.apache.kafka.clients.admin.AdminClientConfig for more options
+    "client.id"         = "kafka-security-manager"
+    "client.id"         = ${?ADMIN_CLIENT_ID}
+    "bootstrap.servers" = ${?KAFKA_BOOTSTRAP_SERVERS}
+    "security.protocol" = "PLAINTEXT"
+    "security.protocol" = ${?ADMIN_CLIENT_SECURITY_PROTOCOL}
+    "sasl.mechanism" = "PLAIN"
+    "sasl.mechanism" = ${?ADMIN_CLIENT_SASL_MECHANISM}
   }
 }
 

--- a/src/main/scala/com/github/simplesteph/ksm/AppConfig.scala
+++ b/src/main/scala/com/github/simplesteph/ksm/AppConfig.scala
@@ -16,7 +16,13 @@ class AppConfig(config: Config) {
     val authorizer: Authorizer =
       CoreUtils.createObject[Authorizer](authorizerClass)
 
-    private val authorizerConfig = config.getConfig("authorizer.config")
+    private val authorizerConfig = config.getConfig(
+      if (authorizer.isInstanceOf[compat.AdminClientAuthorizer]){
+        "authorizer.admin-client-config"
+      } else {
+        "authorizer.config"
+      }
+    )
     private val configMap = authorizerConfig.root().unwrapped().asScala.map {
       case (s, a) => (s, a.toString)
     }

--- a/src/main/scala/com/github/simplesteph/ksm/compat/AdminClientAuthorizer.scala
+++ b/src/main/scala/com/github/simplesteph/ksm/compat/AdminClientAuthorizer.scala
@@ -1,0 +1,97 @@
+package com.github.simplesteph.ksm.compat
+
+import java.util
+
+import kafka.network.RequestChannel
+import kafka.security.SecurityUtils
+import kafka.security.auth.{Acl, Authorizer, Operation, PermissionType, Resource, ResourceType}
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.common.utils.{SecurityUtils => JavaSecurityUtils}
+import org.apache.kafka.common.acl.{AccessControlEntry, AclBindingFilter}
+import org.apache.kafka.common.resource.ResourcePattern
+import org.apache.kafka.common.security.auth.KafkaPrincipal
+
+import scala.collection.JavaConverters._
+
+object JavaAclConversions {
+  def aclFromEntry(entry: AccessControlEntry): Acl = Acl(
+    JavaSecurityUtils.parseKafkaPrincipal(entry.principal()),
+    PermissionType.fromJava(entry.permissionType()),
+    entry.host(),
+    Operation.fromJava(entry.operation())
+  )
+  def resourceFromPattern(pattern: ResourcePattern): Resource = Resource(
+    ResourceType.fromJava(pattern.resourceType),
+    pattern.name(),
+    pattern.patternType()
+  )
+}
+
+trait AdminClientAuthorizerBase extends Authorizer {
+
+  protected def client: AdminClient
+
+  override def addAcls(acls: Set[Acl], resource: Resource): Unit =
+    client.createAcls(
+      acls.map(acl => SecurityUtils.convertToAclBinding(resource, acl)).asJava
+    ).all().get()
+
+  override def removeAcls(acls: Set[Acl], resource: Resource): Boolean =
+    !client
+      .deleteAcls(
+        acls
+          .map(
+            acl => SecurityUtils.convertToAclBinding(resource, acl).toFilter
+          )
+          .asJava
+      )
+      .all()
+      .get()
+      .isEmpty
+
+  override def getAcls(): Map[Resource, Set[Acl]] =
+    client
+      .describeAcls(AclBindingFilter.ANY)
+      .values()
+      .get()
+      .asScala
+      .groupBy(aclBinding => JavaAclConversions.resourceFromPattern(aclBinding.pattern()))
+      .mapValues(_.map(aclBinding => JavaAclConversions.aclFromEntry(aclBinding.entry())).toSet)
+
+  //<editor-fold desc="Interface methods not used by kafka-security-manager">
+
+  override def getAcls(resource: Resource): Set[Acl] = ???
+
+  override def removeAcls(resource: Resource): Boolean = ???
+
+  override def getAcls(principal: KafkaPrincipal): Map[Resource, Set[Acl]] = ???
+
+  override def authorize(session: RequestChannel.Session,
+                         operation: Operation,
+                         resource: Resource): Boolean = ???
+  //</editor-fold>
+}
+
+/** No-argument constructor implementation, admin client initialized by `configure` */
+class AdminClientAuthorizer() extends AdminClientAuthorizerBase {
+
+  private var clientInstance: Option[AdminClient] = None
+
+  override protected def client: AdminClient = clientInstance.getOrElse(
+    throw new IllegalStateException("AdminClient is not yet configured")
+  )
+
+  override def close(): Unit = clientInstance.foreach(_.close())
+
+  override def configure(map: util.Map[String, _]): Unit = {
+    synchronized {
+      clientInstance.foreach(_.close())
+      clientInstance = Some(
+        AdminClient.create(
+          // The only use in security manager provides util.Map[String, String], so it's safe to cast
+          map.asInstanceOf[util.Map[String, Object]]
+        )
+      )
+    }
+  }
+}

--- a/src/test/resources/test-jaas.conf
+++ b/src/test/resources/test-jaas.conf
@@ -1,0 +1,27 @@
+// Zookeeper server
+Server {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  user_admin="admin-secret";
+};
+
+// Broker
+KafkaServer {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  username="admin"
+  password="admin-secret"
+  user_admin="admin-secret";
+};
+
+// Zookeeper Client
+Client {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  username="admin"
+  password="admin-secret";
+};
+
+// Admin Client
+KafkaClient {
+  org.apache.kafka.common.security.plain.PlainLoginModule required
+  username="admin"
+  password="admin-secret";
+};

--- a/src/test/resources/test-jaas.conf
+++ b/src/test/resources/test-jaas.conf
@@ -18,10 +18,3 @@ Client {
   username="admin"
   password="admin-secret";
 };
-
-// Admin Client
-KafkaClient {
-  org.apache.kafka.common.security.plain.PlainLoginModule required
-  username="admin"
-  password="admin-secret";
-};

--- a/src/test/scala/com/github/simplesteph/ksm/AclSynchronizerTest.scala
+++ b/src/test/scala/com/github/simplesteph/ksm/AclSynchronizerTest.scala
@@ -217,6 +217,7 @@ class AclSynchronizerTest extends FlatSpec with EmbeddedKafka with Matchers with
       eventually(timeout(3000 milliseconds), interval(200 milliseconds)) {
         aclSynchronizer.getKafkaAcls shouldBe Set((res1, acl1), (res1, acl2), (res2, acl3))
       }
+      aclSynchronizer.close()
     }
   }
 
@@ -254,6 +255,7 @@ class AclSynchronizerTest extends FlatSpec with EmbeddedKafka with Matchers with
 
       aclSynchronizer.run()
       controlSourceAcl.refreshCalled shouldBe false
+      aclSynchronizer.close()
     }
   }
 

--- a/src/test/scala/com/github/simplesteph/ksm/compat/AdminClientAuthorizerTest.scala
+++ b/src/test/scala/com/github/simplesteph/ksm/compat/AdminClientAuthorizerTest.scala
@@ -1,0 +1,84 @@
+package com.github.simplesteph.ksm.compat
+
+import com.github.simplesteph.ksm.AclSynchronizer
+import com.github.simplesteph.ksm.notification.DummyNotification
+import com.github.simplesteph.ksm.parser.CsvAclParser
+import com.github.simplesteph.ksm.source.DummySourceAcl
+import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
+import org.scalatest.{FlatSpec, Matchers}
+import org.apache.kafka.clients.admin.AdminClientConfig
+
+import scala.collection.JavaConverters._
+
+trait JaasConfiguration {
+  final val jaasPropertyName = "java.security.auth.login.config"
+  def jaasConfig: String = getClass.getClassLoader.getResource("test-jaas.conf").getFile
+
+  def withJaasSystemConfiguration[T](body: => T): T = {
+    val originalPropValue: String = System.getProperty(jaasPropertyName)
+    System.setProperty(jaasPropertyName, jaasConfig)
+    try {
+      body
+    }
+    finally {
+      Option(originalPropValue).fold(
+        System.clearProperty(jaasPropertyName)
+      )(
+        System.setProperty(jaasPropertyName, _)
+      )
+    }
+  }
+}
+
+class AdminClientAuthorizerTest extends FlatSpec with EmbeddedKafka with Matchers with JaasConfiguration {
+
+  implicit final val embeddedKafkaConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(
+    customBrokerProperties = Map(
+      "super.users" -> "User:admin",
+      "authorizer.class.name" -> "kafka.security.auth.SimpleAclAuthorizer",
+      "security.protocol" -> "SASL_PLAINTEXT",
+      "advertised.listeners" -> "SASL_PLAINTEXT://localhost:6001",
+      "listeners" -> "SASL_PLAINTEXT://localhost:6001",
+      "sasl.enabled.mechanisms" -> "PLAIN",
+      "inter.broker.listener.name" -> "SASL_PLAINTEXT",
+      "sasl.mechanism.inter.broker.protocol" -> "PLAIN"
+    )
+  )
+
+  val adminClientConfig: Map[String, Object] = Map(
+    // configuring params similarly like in net.manub.embeddedkafka.ops.AdminOps#createCustomTopic
+    AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> s"localhost:${embeddedKafkaConfig.kafkaPort}",
+    AdminClientConfig.CLIENT_ID_CONFIG -> "ksm-admin-client",
+    AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG -> zkSessionTimeoutMs.toString,
+    AdminClientConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG -> zkConnectionTimeoutMs.toString,
+    // enabling sasl
+    AdminClientConfig.SECURITY_PROTOCOL_CONFIG -> "SASL_PLAINTEXT",
+    "sasl.mechanism" -> "PLAIN"
+  )
+
+  val dummySourceAcl = new DummySourceAcl
+
+  // can't be a val because depends on current jaas configuration mutated in global context
+  def newSynchronizer: AclSynchronizer = {
+    val authorizer = new AdminClientAuthorizer()
+    authorizer.configure(adminClientConfig.asJava)
+    new AclSynchronizer(authorizer, dummySourceAcl, new DummyNotification, new CsvAclParser)
+  }
+
+  "syncronizer with AdminClient based authorizer" should "synchronize acls properly" in {
+    withJaasSystemConfiguration {
+      withRunningKafka {
+        val synchronizer = newSynchronizer
+        synchronizer.getKafkaAcls shouldBe Set.empty
+        // transition to next state happens each time `.refresh(...)` called internally per synchronizer.run
+        dummySourceAcl.sars.foreach(
+          sourceAclResult => {
+            synchronizer.run()
+            synchronizer.getKafkaAcls shouldBe sourceAclResult.acls
+          }
+        )
+        synchronizer.close()
+      }
+    }
+  }
+}

--- a/src/test/scala/com/github/simplesteph/ksm/source/DummySourceAcl.scala
+++ b/src/test/scala/com/github/simplesteph/ksm/source/DummySourceAcl.scala
@@ -30,7 +30,9 @@ class DummySourceAcl extends SourceAcl {
   val sar3 = SourceAclResult(Set(), List())
 
   // all state changes
-  val sars: Iterator[SourceAclResult] = List(sar1, sar2, sar3).iterator
+  val sars: List[SourceAclResult] = List(sar1, sar2, sar3)
+  // a states iterator, shifting its position changes current state
+  private val sarsIterator: Iterator[SourceAclResult] = sars.iterator
 
   override def refresh(aclParser: AclParser): Option[SourceAclResult] = {
     if(noneNext){
@@ -40,7 +42,7 @@ class DummySourceAcl extends SourceAcl {
       errorNext = false
       Some(SourceAclResult(Set((res1, acl1)),
         List[Try[Throwable]](Try(new RuntimeException("triggered error")))))
-    } else Some(sars.next())
+    } else Some(sarsIterator.next())
   }
 
   def setNoneNext(): Unit ={


### PR DESCRIPTION
In some environments (like confluent cloud) a connection to zookeeper is not accessible.
The alternative is to use kafka AdminClient. Current PR adds a compatibility adapter that implements all the Authorizer methods used by KSM on top of AdminClient.
Added test and documentation for that change.

Sbt & scala minor version updated