### PR TITLE
Run AclSyncornizer just once and then stop KSM (Issue #56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [0.8-SNAPSHOT]
-- 
+- Added possibility to run AclSyncornizer just once and then stop KSM (Issue #56)
 
 ## [0.7 - 24/07/2019]
 - Kafka 2.1.1

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The [default configurations](src/main/resources/application.conf) can be overwri
 
 - `KSM_READONLY=false`: enables KSM to synchronize from an External ACL source. The default value is `true`, which prevents KSM from altering ACLs in Zookeeper
 - `KSM_EXTRACT=true`: enable extract mode (get all the ACLs from Kafka formatted as a CSV)
-- `KSM_REFRESH_FREQUENCY_MS=10000`: how often to check for changes in ACLs in Kafka and in the Source. 10000 ms by default
+- `KSM_REFRESH_FREQUENCY_MS=10000`: how often to check for changes in ACLs in Kafka and in the Source. 10000 ms by default. If it's set to `-1` then KMS executes ACL synchronization just once and exits
 - `AUTHORIZER_CLASS`: authorizer class for ACL operations. Default is `SimpleAclAuthorizer`, configured with
   - `AUTHORIZER_ZOOKEEPER_CONNECT`: zookeeper connection string
   - `AUTHORIZER_ZOOKEEPER_SET_ACL=true` (default `false`): set to true if you want your ACLs in Zookeeper to be secure (you probably do want them to be secure) - when in doubt set as the same as your Kafka brokers.

--- a/src/main/scala/com/github/simplesteph/ksm/KafkaSecurityManager.scala
+++ b/src/main/scala/com/github/simplesteph/ksm/KafkaSecurityManager.scala
@@ -55,8 +55,10 @@ object KafkaSecurityManager extends App {
     try {
       //if appConfig.KSM.refreshFrequencyMs is equal to -1 the aclSyngronizer is run just once.
       if(appConfig.KSM.refreshFrequencyMs == -1){
+        log.info("Single run mode: ACL will be synchornized once.")
         aclSynchronizer.run()
       } else {
+        log.info("Continues mode: ACL will be synchornized with period "+ appConfig.KSM.refreshFrequencyMs +" ms.")
         val handle = scheduler.scheduleAtFixedRate(aclSynchronizer, 0, appConfig.KSM.refreshFrequencyMs, TimeUnit.MILLISECONDS)
         handle.get
       }

--- a/src/main/scala/com/github/simplesteph/ksm/KafkaSecurityManager.scala
+++ b/src/main/scala/com/github/simplesteph/ksm/KafkaSecurityManager.scala
@@ -51,11 +51,15 @@ object KafkaSecurityManager extends App {
         shutdown()
       }
     })
-
-    val handle = scheduler.scheduleAtFixedRate(aclSynchronizer, 0, appConfig.KSM.refreshFrequencyMs, TimeUnit.MILLISECONDS)
-
+    
     try {
-      handle.get
+      //if appConfig.KSM.refreshFrequencyMs is equal to -1 the aclSyngronizer is run just once.
+      if(appConfig.KSM.refreshFrequencyMs == -1){
+        aclSynchronizer.run()
+      } else {
+        val handle = scheduler.scheduleAtFixedRate(aclSynchronizer, 0, appConfig.KSM.refreshFrequencyMs, TimeUnit.MILLISECONDS)
+        handle.get
+      }
     }
     catch {
       case e: ExecutionException =>

--- a/src/main/scala/com/github/simplesteph/ksm/KafkaSecurityManager.scala
+++ b/src/main/scala/com/github/simplesteph/ksm/KafkaSecurityManager.scala
@@ -58,7 +58,7 @@ object KafkaSecurityManager extends App {
         log.info("Single run mode: ACL will be synchornized once.")
         aclSynchronizer.run()
       } else {
-        log.info("Continues mode: ACL will be synchornized with period "+ appConfig.KSM.refreshFrequencyMs +" ms.")
+        log.info("Continuous mode: ACL will be synchronized every "+ appConfig.KSM.refreshFrequencyMs +" ms.")
         val handle = scheduler.scheduleAtFixedRate(aclSynchronizer, 0, appConfig.KSM.refreshFrequencyMs, TimeUnit.MILLISECONDS)
         handle.get
       }


### PR DESCRIPTION
 Hi Stephane,

as agreed, I'm adding PR for issue #56 .

I didn't want to introduce a new variable for a single KSM run, so I reused `KSM_REFRESH_FREQUENCY_MS` and allowed option `-1` as a marker to run ACL Synchronization just once and then exit.

Please let me know your comments.

Best regards,
Petros