### PR TITLE
Add classpathjar plugin to fix long path issues when running executables

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ scalaVersion := "2.12.8"
 lazy val root = (project in file("."))
   .enablePlugins(JavaAppPackaging)
   .enablePlugins(DockerPlugin)
+  .enablePlugins(ClasspathJarPlugin)
 
 
 resolvers ++= Seq(


### PR DESCRIPTION
Used solution mentioned in https://www.scala-sbt.org/sbt-native-packager/recipes/longclasspath.html