### PR TITLE
Make http request more robust

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -116,15 +116,20 @@ source {
       url = ${?SOURCE_BITBUCKET_CLOUD_API_URL}
     }
 
-   organization = ${?SOURCE_BITBUCKET_CLOUD_ORGANIZATION}
-   repo = "kafka-acls"
-   repo = ${?SOURCE_BITBUCKET_CLOUD_REPO}
-   filepath = "acls.csv"
-   filepath = ${?SOURCE_BITBUCKET_CLOUD_FILEPATH}
-   auth {
+    organization = ${?SOURCE_BITBUCKET_CLOUD_ORGANIZATION}
+    repo = "kafka-acls"
+    repo = ${?SOURCE_BITBUCKET_CLOUD_REPO}
+    filepath = "acls.csv"
+    filepath = ${?SOURCE_BITBUCKET_CLOUD_FILEPATH}
+    auth {
       username = ${?SOURCE_BITBUCKET_CLOUD_AUTH_USERNAME}
       password = ${?SOURCE_BITBUCKET_CLOUD_AUTH_PASSWORD}
     }
+
+    http.conn.timeout.ms = 1000
+    http.conn.timeout.ms = ${?SOURCE_BITBUCKET_CLOUD_HTTP_CONN_TIMEOUT_MS}
+    http.read.timeout.ms = 5000
+    http.read.timeout.ms = ${?SOURCE_BITBUCKET_CLOUD__HTTP_READ_TIMEOUT_MS}
   }
 }
 


### PR DESCRIPTION
I got the error of "failed because connect timed out (skinny.http.HTTP$)" during test. In this case, applied an empty acls rules and remove all the existing rules on Kafka. Found that enableThrowingIOException is false by default, which may not throw exception in some case. 
I wasn't able to reproduce this error, but I think the change in this PR can make it more robust.