### PR TITLE
Fix CSV Sample column order error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A sample CSV to manage ACL is:
 ```
 KafkaPrincipal,ResourceType,PatternType,ResourceName,Operation,PermissionType,Host
 User:alice,Topic,LITERAL,foo,Read,Allow,*
-User:bob,Group,bar,PREFIXED,Write,Deny,12.34.56.78
+User:bob,Group,PREFIXED,bar,Write,Deny,12.34.56.78
 User:peter,Cluster,LITERAL,kafka-cluster,Create,Allow,*
 ```
 


### PR DESCRIPTION
Fix the second non-header row in the CSV sample in README.md, by exchanging the data for the PatternType and ResourceName columns in that row.