### PR TITLE
fix S3SourceAcl reading from BufferedReader bug

### DIFF
--- a/src/main/scala/com/github/simplesteph/ksm/source/S3SourceAcl.scala
+++ b/src/main/scala/com/github/simplesteph/ksm/source/S3SourceAcl.scala
@@ -73,7 +73,7 @@ class S3SourceAcl extends SourceAcl {
         lastModified = bucket.getObjectMetadata.getLastModified
 
         val content =
-          Stream.continually(reader.readLine()).takeWhile(_ != null).mkString
+          Stream.continually(reader.readLine()).takeWhile(_ != null).map(_.concat("\n")).mkString
 
         reader.close()
         bucket.close()

--- a/src/test/scala/com/github/simplesteph/ksm/source/S3SourceAclTest.scala
+++ b/src/test/scala/com/github/simplesteph/ksm/source/S3SourceAclTest.scala
@@ -16,7 +16,10 @@ class S3SourceAclTest extends FlatSpec with Matchers {
     val bucket = "testbucket"
     val key = UUID.randomUUID().toString
     val region = "us-east-1"
-    val content = "hello"
+    val content =
+      """hello
+        |world
+        |""".stripMargin
 
     val client = s3SourceAcl.s3Client()
 
@@ -32,7 +35,7 @@ class S3SourceAclTest extends FlatSpec with Matchers {
     reader match {
       case None => fail() // didn't read
       case Some(x: BufferedReader) =>
-        val read = Stream.continually(x.readLine()).takeWhile(Option(_).nonEmpty).mkString
+        val read = Stream.continually(x.readLine()).takeWhile(Option(_).nonEmpty).map(_.concat("\n")).mkString
 
         content shouldBe read
     }


### PR DESCRIPTION
S3SourceAcl not working, because "\n" was lost when converting to string, leading to parse failure.