### PR TITLE
Add a config to control how often notifications on ACL Source refreshes are sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.10 - 02/18/2021]
+- Added config to control how often notifications on ACL Source refreshes are sent
+- Fixed (#87) by ensuring that content from S3 buckets is read from the stream completely before the bucket is closed
+- Fixed (#88) S3SourceAcl from BufferedReader bug
+
 ## [0.9 - 08/07/2020]
 - Upgrade to Kafka 2.5.0
 - Added Bitbucket Cloud as an ACL source

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The [default configurations](src/main/resources/application.conf) can be overwri
 - `KSM_READONLY=false`: enables KSM to synchronize from an External ACL source. The default value is `true`, which prevents KSM from altering ACLs in Zookeeper
 - `KSM_EXTRACT=true`: enable extract mode (get all the ACLs from Kafka formatted as a CSV)
 - `KSM_REFRESH_FREQUENCY_MS=10000`: how often to check for changes in ACLs in Kafka and in the Source. 10000 ms by default. If it's set to `0` or negative value, for example `-1`, then KMS executes ACL synchronization just once and exits
+- `KSM_NUM_FAILED_REFRESHES_BEFORE_NOTIFICATION=1`: how many times that the refresh of a Source needs to fail (e.g. HTTP timeouts) before a notification is sent. Any value less than or equal to `1` here will notify on every failure to refresh.
 - `AUTHORIZER_CLASS`: authorizer class for ACL operations. Default is `SimpleAclAuthorizer`, configured with
   - `AUTHORIZER_ZOOKEEPER_CONNECT`: zookeeper connection string
   - `AUTHORIZER_ZOOKEEPER_SET_ACL=true` (default `false`): set to true if you want your ACLs in Zookeeper to be secure (you probably do want them to be secure) - when in doubt set as the same as your Kafka brokers.
@@ -228,7 +229,8 @@ TODO: Mention to look for inter broker protocol version before doing this
 
 KSM Version | Kafka Version | Notes
 --- | --- | ---
-0.9-SNAPSHOT | 2.3.1 | TODO: Upgrade to Kafka 2.4.x (PR welcome)
+0.10 | 2.5.x | Add configurable num failed refreshes before notification 
+0.9 | 2.5.x | Upgrade to Kafka 2.5.x
 0.8 | 2.3.1 | Add a "run once" mode
 0.7 | 2.1.1 | Kafka Based ACL refresher available (no zookeeper dependency)
 0.6 | 2.0.0 | important stability fixes - please update

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -6,6 +6,9 @@ ksm {
   extract = false
   extract = ${?KSM_EXTRACT}
 
+  num.failed.refreshes.before.notification = 1
+  num.failed.refreshes.before.notification = ${?KSM_NUM_FAILED_REFRESHES_BEFORE_NOTIFICATION}
+
   refresh.frequency.ms = 10000
   refresh.frequency.ms = ${?KSM_REFRESH_FREQUENCY_MS}
 

--- a/src/main/scala/com/github/simplesteph/ksm/AppConfig.scala
+++ b/src/main/scala/com/github/simplesteph/ksm/AppConfig.scala
@@ -55,6 +55,7 @@ class AppConfig(config: Config) {
   object KSM {
     private val ksmConfig = config.getConfig("ksm")
     val refreshFrequencyMs: Int = ksmConfig.getInt("refresh.frequency.ms")
+    val numFailedRefreshesBeforeNotification: Int = ksmConfig.getInt("num.failed.refreshes.before.notification")
     val extract: Boolean = ksmConfig.getBoolean("extract")
     val readOnly: Boolean = ksmConfig.getBoolean("readonly")
   }

--- a/src/main/scala/com/github/simplesteph/ksm/KafkaSecurityManager.scala
+++ b/src/main/scala/com/github/simplesteph/ksm/KafkaSecurityManager.scala
@@ -36,6 +36,7 @@ object KafkaSecurityManager extends App {
       appConfig.Source.sourceAcl,
       appConfig.Notification.notification,
       aclParser,
+      appConfig.KSM.numFailedRefreshesBeforeNotification,
       appConfig.KSM.readOnly
     )
 

--- a/src/test/scala/com/github/simplesteph/ksm/compat/AdminClientAuthorizerTest.scala
+++ b/src/test/scala/com/github/simplesteph/ksm/compat/AdminClientAuthorizerTest.scala
@@ -93,7 +93,8 @@ class AdminClientAuthorizerTest
       authorizer,
       dummySourceAcl,
       new DummyNotification,
-      new CsvAclParser
+      new CsvAclParser,
+      1
     )
   }
 

--- a/src/test/scala/com/github/simplesteph/ksm/grpc/KsmServiceImplTest.scala
+++ b/src/test/scala/com/github/simplesteph/ksm/grpc/KsmServiceImplTest.scala
@@ -19,7 +19,8 @@ class KsmServiceImplTest extends AsyncFlatSpec with Matchers {
       new DummyAuthorizer(),
       dummySourceAcl,
       new DummyNotification,
-      new CsvAclParser
+      new CsvAclParser,
+      1
     )
   )
 


### PR DESCRIPTION
First off, this application is awesome. Thank you for writing it.

So, we are receiving a large number of notifications due to timeouts on our ACL Source, and I thought that it might be worthwhile for there to be a config detailing how many failures should be encountered before an error notification is sent. This is common practice in alerting tools, which I believe that the Notification portion of this application falls under.

Please let me know if I completely missed the mark as far as Scala coding conventions go. I am honestly quite a Scala noob. I tried to follow the testing and coding practices that existed in the codebase.

![](https://bukk.it/shh.jpg)