### PR TITLE
feat(HttpSourceAcl): Add optional configuration header configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ The [default configurations](src/main/resources/application.conf) can be overwri
         - `SOURCE_HTTP_AUTH_GOOGLEIAM_SERVICE_ACCOUNT_KEY` Google Service Account Key in JSON string encoded. If not the key isn't configured, it'll try to get the token from environment.
         - `SOURCE_HTTP_AUTH_GOOGLEIAM_TARGET_AUDIENCE` Google Target Audience for token authentication.
         - `SOURCE_HTTP_CONTENT_LENGTH_HEADER_REQUIRED` Whether the `Content-Length` header is required in the HTTP response. Default is `false`.
+        - `SOURCE_HTTP_HEADER_OVERRIDES` Extra HTTP headers to include in the HTTP requests, overrides potential headers added from the authentication configuration. Default is "". The expected format is CSV such as `"Accept-Encoding:text/plain,Content-Type:text/plain"`.
 
 - `NOTIFICATION_CLASS`: Class for notification in case of ACL changes in Kafka.
     - `io.conduktor.ksm.notification.ConsoleNotification` (default): Print changes to the console. Useful for logging

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ The [default configurations](src/main/resources/application.conf) can be overwri
         - `SOURCE_HTTP_AUTH_GOOGLEIAM_SERVICE_ACCOUNT` Google Service Account name.
         - `SOURCE_HTTP_AUTH_GOOGLEIAM_SERVICE_ACCOUNT_KEY` Google Service Account Key in JSON string encoded. If not the key isn't configured, it'll try to get the token from environment.
         - `SOURCE_HTTP_AUTH_GOOGLEIAM_TARGET_AUDIENCE` Google Target Audience for token authentication.
+        - `SOURCE_HTTP_CONTENT_LENGTH_HEADER_REQUIRED` Whether the `Content-Length` header is required in the HTTP response. Default is `false`.
 
 - `NOTIFICATION_CLASS`: Class for notification in case of ACL changes in Kafka.
     - `io.conduktor.ksm.notification.ConsoleNotification` (default): Print changes to the console. Useful for logging

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -158,6 +158,11 @@ source {
             target-audience = ${?SOURCE_HTTP_AUTH_GOOGLEIAM_TARGET_AUDIENCE}
         }
     }
+
+    contentlength {
+        required = false
+        required = ${?SOURCE_HTTP_CONTENT_LENGTH_HEADER_REQUIRED}
+    }
   }
 }
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -163,6 +163,9 @@ source {
         required = false
         required = ${?SOURCE_HTTP_CONTENT_LENGTH_HEADER_REQUIRED}
     }
+
+    headers = ""
+    headers = ${?SOURCE_HTTP_HEADER_OVERRIDES}
   }
 }
 

--- a/src/main/scala/io/conduktor/ksm/source/HttpSourceAcl.scala
+++ b/src/main/scala/io/conduktor/ksm/source/HttpSourceAcl.scala
@@ -1,10 +1,9 @@
 package io.conduktor.ksm.source
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigException}
 import io.conduktor.ksm.parser.AclParserRegistry
 import io.conduktor.ksm.source.security.{GoogleIAM, HttpAuthentication}
-import org.apache.http.HttpHeaders.CONTENT_LENGTH
+import org.apache.http.HttpHeaders.{CONTENT_LENGTH, CONTENT_TYPE, IF_MODIFIED_SINCE, LAST_MODIFIED}
 import org.slf4j.LoggerFactory
 import skinny.http._
 
@@ -25,6 +24,7 @@ class HttpSourceAcl(parserRegistry: AclParserRegistry)
   final val METHOD = "method"
   final val AUTHENTICATION_TYPE = "auth.type"
   final val REQUIRE_CONTENT_LENGTH_HEADER = "contentlength.required"
+  final val HEADERS = "headers"
 
   var lastModified: Option[String] = None
 
@@ -33,6 +33,7 @@ class HttpSourceAcl(parserRegistry: AclParserRegistry)
   var httpMethod: Method = _
   var authentication: Option[HttpAuthentication] = _
   var requireContentLengthHeader: Boolean = _
+  var headers: Map[String, String] = _
 
   def configure(url: String, parser: String, method: String): Unit = {
     configure(url, parser, method, None)
@@ -43,36 +44,72 @@ class HttpSourceAcl(parserRegistry: AclParserRegistry)
   }
 
   def configure(url: String, parser: String, method: String, authentication: Option[HttpAuthentication], requireContentLengthHeader: Boolean): Unit = {
+    configure(url, parser, method, authentication, requireContentLengthHeader, Map.empty)
+  }
+
+  def configure(url: String, parser: String, method: String,
+                authentication: Option[HttpAuthentication],
+                requireContentLengthHeader: Boolean, headers: Map[String, String]): Unit = {
     this.uri = url
     this.parser = parser
     this.httpMethod = new Method(method)
     this.authentication = authentication
     this.requireContentLengthHeader = requireContentLengthHeader
+    this.headers = headers
   }
 
     /**
     * internal config definition for the module
     */
   override def configure(config: Config): Unit = {
-    this.uri = config.getString(URL)
-    log.info("URL: {}", this.uri)
+    val uri = config.getString(URL)
+    log.info("URL: {}", uri)
 
-    this.parser = config.getString(PARSER)
-    log.info("PARSER: {}", this.parser)
+    val parser = config.getString(PARSER)
+    log.info("PARSER: {}", parser)
 
-    this.httpMethod = new Method(config.getString(METHOD))
-    log.info("HTTP Method: {}", this.httpMethod)
+    val httpMethod = config.getString(METHOD)
+    log.info("HTTP Method: {}", httpMethod)
 
-    this.authentication = config.getString(AUTHENTICATION_TYPE) match {
+    val authentication = config.getString(AUTHENTICATION_TYPE) match {
       case "googleiam" => Some(new GoogleIAM(config.getConfig("auth.googleiam")))
       case _ => None
     }
-    log.info("HTTP Authentication: {}", this.authentication)
+    log.info("HTTP Authentication: {}", authentication)
 
+    val requireContentLengthHeader: Boolean = getContentLengthHeaderRequiredConfiguration(config)
+    log.info("HTTP Content-Length Header required: {}", requireContentLengthHeader)
+
+    val headers: Map[String, String] = getHeaderConfiguration(config)
+    log.info("Configured HTTP Headers: {}", headers)
+
+    configure(uri, parser, httpMethod, authentication, requireContentLengthHeader, headers)
+  }
+
+  def getContentLengthHeaderRequiredConfiguration(config: Config): Boolean = {
+    var requireContentLengthHeader = false
     if (config.hasPath(REQUIRE_CONTENT_LENGTH_HEADER)) {
-      this.requireContentLengthHeader = config.getBoolean(REQUIRE_CONTENT_LENGTH_HEADER)
+      requireContentLengthHeader = config.getBoolean(REQUIRE_CONTENT_LENGTH_HEADER)
     }
-    log.info("HTTP Content-Length Header required: {}", this.requireContentLengthHeader)
+    requireContentLengthHeader
+  }
+
+  def getHeaderConfiguration(config: Config): Map[String, String] = {
+    var headers = Map.empty[String, String]
+    if (!config.hasPath(HEADERS)) {
+      return headers
+    }
+    val headerConfig = config.getString(HEADERS)
+    headerConfig.split(",").foreach { header =>
+      val headerKeyValue = header.split(":")
+      if (headerKeyValue.length != 2) {
+        throw new ConfigException.BadValue(CONFIG_PREFIX + "." + HEADERS, "Invalid header configuration. Expected format: 'name1:value1,name2:value2'")
+      }
+      val name = headerKeyValue(0).trim
+      val value = headerKeyValue(1).trim
+      headers += (name -> value)
+    }
+    headers
   }
 
   /**
@@ -90,28 +127,32 @@ class HttpSourceAcl(parserRegistry: AclParserRegistry)
 
     val request: Request = new Request(uri)
     // super important in order to properly fail in case a timeout happens for example
-    request.enableThrowingIOException(true)
-    request.followRedirects(false)
-    request.connectTimeoutMillis(Int.MaxValue)
-    request.readTimeoutMillis(Int.MaxValue)
+    request
+      .enableThrowingIOException(true)
+      .followRedirects(false)
+      .connectTimeoutMillis(Int.MaxValue)
+      .readTimeoutMillis(Int.MaxValue)
 
     authentication.map(authentication => request.header(authentication.authHeaderKey, authentication.authHeaderValue))
 
     // we use this header for the 304
-    lastModified.foreach(header => request.header("If-Modified-Since", header))
-    request.header("Content-Type", "text/plain") // only type supported for now
+    lastModified.foreach(header => request.header(IF_MODIFIED_SINCE, header))
+    request.header(CONTENT_TYPE, "text/plain") // only type supported for now
+
+    headers.foreach {case (name, value) => request.header(name, value)}
+
     val response: Response = HTTP.request(httpMethod, request)
 
     response.status match {
       case 200 =>
-        lastModified = response.header("Last-Modified")
+        lastModified = response.header(LAST_MODIFIED)
 
         // as skinny HTTP doesn't validate HTTP Header Content-Length
         validateBodyLength(response)
 
         Some(
           ParsingContext(
-            parserRegistry.getParser(this.parser),
+            parserRegistry.getParser(parser),
             new BufferedReader(new StringReader(response.textBody))
           )
         )


### PR DESCRIPTION
Add 2 optional configuration properties:
* `contentlength.required`: Defaults to `false`, fail fast rather than skipping HTTP response body length validation when set to `true`. Corresponding environment variable: `SOURCE_HTTP_CONTENT_LENGTH_HEADER_REQUIRED`
* `headers`: Defaults to empty, adds extra headers on the HTTP requests sent by the `HttpSourceAcl`, overriding default headers in case of duplicates, including those added from another configuration, authentication for example. Corresponding environment variable: `SOURCE_HTTP_HEADER_OVERRIDES` formatted as CSV such as "k1:v1,k2:v2"